### PR TITLE
swap argument values in sentinel push_front

### DIFF
--- a/cathy/dlist.h
+++ b/cathy/dlist.h
@@ -237,7 +237,7 @@ public:
 
 template <typename T>
 void Sentinel<T>::push_front(const T& data){
-    Node* nn=new Node(data,front_,front_->next_);
+    Node* nn=new Node(data,front_->next_,front_);
     front_->next_->prev_=nn;
     front_->next_=nn;
 }


### PR DESCRIPTION
Node constructor parameters are the other way around, so I flipped the arguments for `next` and `prev` pointers in the Sentinel `push_front` function. 
Fixes issue #2.